### PR TITLE
build: Optimize Dockerfile.goreleaser by adding UPX compression for faster download time

### DIFF
--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,11 +1,12 @@
-FROM gcr.io/distroless/static-debian12:nonroot
-
+FROM alpine:latest AS builder
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM
+RUN apk add --no-cache upx
+COPY google-calendar-agent /artifacts/agent
+RUN upx --best --lzma /artifacts/agent
 
-COPY google-calendar-agent /google-calendar-agent
-
+FROM gcr.io/distroless/static-debian12:nonroot
+COPY --from=builder /artifacts/agent /google-calendar-agent
 USER nonroot:nonroot
 EXPOSE 8080
-
 ENTRYPOINT ["/google-calendar-agent"]


### PR DESCRIPTION
## Summary

Optimize Dockerfile.goreleaser by adding UPX compression.

This will get up to 70% more less storage - which means faster download time.