### PR TITLE
docs: Example cleanup

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -32,6 +32,60 @@ This example demonstrates how to run the Google Calendar Agent with the Inferenc
 4. Inference Gateway uses LLM providers for natural language processing
 5. Response flows back through Gateway to the user
 
+### Direct Access with A2A Debugger
+
+```
+┌─────────────────┐    ┌─────────────────┐    ┌─────────────────┐
+│                 │    │                 │    │                 |
+│ A2A Debugger    │───▶│ Calendar Agent  │───▶│ Google Calendar │
+│ CLI Tool        │    │ (A2A Server)    │    │ API             │
+│                 │    │ (Port 8080)     │    │                 │
+└─────────────────┘    └─────────────────┘    └─────────────────┘
+        │                       │
+        │                       │
+        ▼                       ▼
+┌─────────────────┐    ┌─────────────────┐
+│                 │    │                 │
+│ Task Management │    │ LLM Engine      │
+│ • List tasks    │    │ (Optional)      │
+│ • View history  │    │ For AI features │
+│ • Submit tasks  │    │                 │
+└─────────────────┘    └─────────────────┘
+```
+
+**Direct Access Flow:**
+
+1. **A2A Debugger** connects directly to the Calendar Agent's A2A server endpoint
+2. **Submit Tasks**: Send JSON-RPC 2.0 requests directly to the agent
+3. **Task Management**: List, monitor, and retrieve task details and conversation history
+4. **Real-time Debugging**: View agent responses, tool calls, and execution flow
+5. **Agent Tools**: Direct access to calendar operations without gateway overhead
+
+**A2A Debugger Commands:**
+
+```bash
+# Test connection and get agent capabilities
+docker run --rm a2a-debugger connect
+docker run --rm a2a-debugger agent-card
+
+# Submit tasks directly to the agent
+docker run --rm a2a-debugger tasks submit "List my events for today"
+docker run --rm a2a-debugger tasks submit "Create a meeting tomorrow at 2 PM"
+
+# Monitor and debug
+docker run --rm a2a-debugger tasks list
+docker run --rm a2a-debugger tasks get <task-id>
+docker run --rm a2a-debugger tasks history <context-id>
+```
+
+**Benefits of Direct Access:**
+
+- **Faster Response**: No gateway overhead for debugging
+- **Direct Tool Access**: Immediate access to calendar operations
+- **Enhanced Debugging**: Full visibility into agent internals
+- **Task Monitoring**: Real-time task status and conversation history
+- **Development Workflow**: Perfect for agent development and testing
+
 ## Features
 
 - **Google Calendar Agent**: Manages calendar events with natural language processing

--- a/example/README.md
+++ b/example/README.md
@@ -1,36 +1,16 @@
 # Basic Example
 
-This example demonstrates how to run the Google Calendar Agent with the Inference Gateway using Docker Compose. The setup includes both services configured to work together, providing a complete AI-powered calendar management solution, along with an interactive Go client for testing.
+This example demonstrates how to run the Google Calendar Agent with the Inference Gateway using Docker Compose. The setup includes both services configured to work together, providing a complete AI-powered calendar management solution.
 
 ## Architecture
 
-### Option 1: Direct Connection to Calendar Agent
-
-```
-┌─────────────────┐    ┌─────────────────┐
-│                 │    │                 │
-│ Interactive Go  │───▶│ Calendar Agent  │
-│ Client          │    │ (Port 8081)     │
-│                 │    │                 │
-└─────────────────┘    └─────────────────┘
-                                │
-                                │
-                                ▼
-                       ┌─────────────────┐
-                       │                 │
-                       │ Google Calendar │
-                       │ API             │
-                       │                 │
-                       └─────────────────┘
-```
-
-### Option 2: Through Inference Gateway
+### Through Inference Gateway
 
 ```
 ┌─────────────────┐    ┌─────────────────┐    ┌─────────────────┐
-│                 │    │                 │    │                 │
-│ Interactive Go  │───▶│ Inference       │───▶│ Calendar Agent  │
-│ Client          │    │ Gateway         │    │                 │
+│                 │    │                 │    |                 |
+│ User/Client     │───▶│ Inference       │───▶│ Calendar Agent  │
+│                 │    │ Gateway         │    │                 │
 │                 │    │ (Port 8080)     │    │                 │
 └─────────────────┘    └─────────────────┘    └─────────────────┘
                                 │                       │
@@ -45,14 +25,6 @@ This example demonstrates how to run the Google Calendar Agent with the Inferenc
 ```
 
 **Flow Description:**
-
-**Option 1 (Direct Connection):**
-
-1. Interactive client connects directly to Calendar Agent via A2A protocol
-2. Calendar Agent processes requests and interacts with Google Calendar API
-3. Responses are sent back directly to the client
-
-**Option 2 (Through Gateway):**
 
 1. User sends request to Inference Gateway (port 8080)
 2. Inference Gateway processes the request and determines if an agent is needed
@@ -157,10 +129,10 @@ Set on the Inference Gateway `A2A_EXPOSE=true` and bring up the containers.
 curl http://localhost:8080/v1/a2a/agents
 ```
 
-#### Test A2A Protocol (Example)
+#### Test Chat Completions
 
 ```bash
-# Test through Inference Gateway (recommended)
+# Test through Inference Gateway
 curl -X POST http://localhost:8080/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
@@ -173,108 +145,6 @@ curl -X POST http://localhost:8080/v1/chat/completions \
     ]
   }'
 ```
-
-### 5. Interactive Go Client
-
-The example includes an interactive Go client that demonstrates how to use the A2A ADK to communicate with the Google Calendar Agent.
-
-#### Setup
-
-```bash
-# Navigate to client directory
-cd client
-
-# Copy environment configuration
-cp .env.example .env
-
-# Edit configuration if needed
-nano .env
-```
-
-#### Configuration Options
-
-| Environment Variable | Description                          | Default                     |
-| -------------------- | ------------------------------------ | --------------------------- |
-| `A2A_SERVER_URL`     | A2A server endpoint                  | `http://localhost:8080/a2a` |
-| `POLL_INTERVAL`      | Polling interval for async responses | `1s`                        |
-| `MAX_POLL_TIMEOUT`   | Maximum time to wait for completion  | `60s`                       |
-| `LOG_LEVEL`          | Log level (debug, info, warn, error) | `info`                      |
-| `USE_ASYNC_MODE`     | Use async mode for better UX         | `true`                      |
-
-#### Running the Client
-
-```bash
-docker compose run --rm a2a-client
-```
-
-#### Example Usage
-
-The interactive client provides a command-line interface where you can type natural language queries:
-
-```
-🗓️  Google Calendar Agent - Interactive Client
-============================================================
-Type your questions or commands about your Google Calendar.
-Examples:
-  • What meetings do I have today?
-  • Schedule a meeting with John tomorrow at 2 PM
-  • Show my calendar for next week
-  • Cancel my 3 PM meeting
-  • help - Show more examples
-  • quit - Exit the client
-============================================================
-
-📅 You: What's on my calendar today?
-🤔 Thinking...
-🤖 Agent: Here are your events for today:
-
-1. Team Standup - 9:00 AM - 9:30 AM
-2. Project Review - 2:00 PM - 3:00 PM
-3. Client Call - 4:00 PM - 5:00 PM
-
-📅 You: Schedule a lunch meeting with Sarah tomorrow at 12 PM
-🤔 Thinking...
-🤖 Agent: I've scheduled a lunch meeting with Sarah for tomorrow at 12:00 PM.
-
-📅 You: help
-📖 Available Commands and Examples:
---------------------------------------------------
-Calendar Queries:
-  • What's on my calendar today?
-  • Show me my meetings for tomorrow
-  • What meetings do I have this week?
-  • Do I have any free time on Friday?
-
-Event Management:
-  • Schedule a meeting with Sarah at 3 PM tomorrow
-  • Create a 1-hour lunch meeting next Tuesday
-  • Book a team standup every Monday at 9 AM
-  • Cancel my 2 PM meeting today
-  • Move my 4 PM meeting to 5 PM
-
-Time Management:
-  • When is my next meeting?
-  • How much free time do I have today?
-  • Find a 30-minute slot for a call this week
-
-Commands:
-  • help or h - Show this help message
-  • clear - Clear the screen
-  • quit, exit, or q - Exit the client
---------------------------------------------------
-
-📅 You: quit
-👋 Goodbye!
-```
-
-#### Features
-
-- **Interactive Loop**: Continuous conversation with context preservation
-- **Async/Sync Support**: Configurable response handling with visual feedback
-- **Error Handling**: Graceful error handling with user-friendly messages
-- **Rich CLI**: Colorful interface with emojis and formatting
-- **Help System**: Built-in help and examples
-- **Configurable Logging**: Adjustable log levels for debugging
 
 ## Available Tasks
 
@@ -406,7 +276,7 @@ LLM_MODEL=@cf/meta/llama-3.1-8b-instruct
 ### List Calendar Events
 
 ```bash
-# Through Inference Gateway (recommended)
+# Through Inference Gateway
 curl -X POST http://localhost:8080/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
@@ -423,7 +293,7 @@ curl -X POST http://localhost:8080/v1/chat/completions \
 ### Create Calendar Event
 
 ```bash
-# Through Inference Gateway (recommended)
+# Through Inference Gateway
 curl -X POST http://localhost:8080/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
@@ -440,7 +310,7 @@ curl -X POST http://localhost:8080/v1/chat/completions \
 ### Update Calendar Event
 
 ```bash
-# Through Inference Gateway (recommended)
+# Through Inference Gateway
 curl -X POST http://localhost:8080/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
@@ -457,7 +327,7 @@ curl -X POST http://localhost:8080/v1/chat/completions \
 ### Delete Calendar Event
 
 ```bash
-# Through Inference Gateway (recommended)
+# Through Inference Gateway
 curl -X POST http://localhost:8080/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{

--- a/example/README.md
+++ b/example/README.md
@@ -65,17 +65,17 @@ This example demonstrates how to run the Google Calendar Agent with the Inferenc
 
 ```bash
 # Test connection and get agent capabilities
-docker run --rm a2a-debugger connect
-docker run --rm a2a-debugger agent-card
+docker compose run --rm a2a-debugger connect
+docker compose run --rm a2a-debugger agent-card
 
 # Submit tasks directly to the agent
-docker run --rm a2a-debugger tasks submit "List my events for today"
-docker run --rm a2a-debugger tasks submit "Create a meeting tomorrow at 2 PM"
+docker compose run --rm a2a-debugger tasks submit "List my events for today"
+docker compose run --rm a2a-debugger tasks submit "Create a meeting tomorrow at 2 PM"
 
 # Monitor and debug
-docker run --rm a2a-debugger tasks list
-docker run --rm a2a-debugger tasks get <task-id>
-docker run --rm a2a-debugger tasks history <context-id>
+docker compose run --rm a2a-debugger tasks list
+docker compose run --rm a2a-debugger tasks get <task-id>
+docker compose run --rm a2a-debugger tasks history <context-id>
 ```
 
 **Benefits of Direct Access:**

--- a/example/docker-compose.yaml
+++ b/example/docker-compose.yaml
@@ -19,8 +19,6 @@ services:
       context: ..
       dockerfile: Dockerfile
     pull_policy: always
-    ports:
-      - "8081:8080"
     env_file:
       - .env.agent
     restart: unless-stopped


### PR DESCRIPTION
## Summary

Cleaning up the example to reflect the recent changes.

- **docs: Update README to remove interactive Go client references and clarify architecture**
- **fix: Remove port mapping for google-calendar-agent service**
- **docs: Add A2A Debugger section with usage examples and benefits**
