### PR TITLE
docs: author spec.examples and spec.documentation in agent.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,11 +80,25 @@ infer agents add google-calendar-agent http://localhost:8080 \
 | `check_conflicts` | Check for scheduling conflicts in the specified time range | endTime, startTime |
 | `get_current_datetime` | Return the current date/time and the user's IANA timezone. Call this FIRST for any time-relative request (today, tomorrow, next Friday) before emitting RFC3339 timestamps to other calendar tools, so events land in the user's local timezone instead of an LLM-assumed default. | None |
 
+## Examples
+
+| Example | Description |
+|---------|-------------|
+| List upcoming events | Ask "What's on my calendar this week?" and the agent calls list_calendar_events to return your upcoming events with their times, locations, and attendees. |
+| Schedule a conflict-free meeting | Ask "Schedule a 30-minute sync with alice@example.com tomorrow afternoon." The schedule-meeting skill chains find_available_time, check_conflicts, and create_calendar_event to book a slot that does not overlap anything already on the calendar. |
+| Find a free time slot | Ask "Find a free 1-hour slot on Thursday" and the agent uses find_available_time to propose open windows, anchoring "Thursday" to your timezone with get_current_datetime first. |
+| Reschedule or cancel an event | Ask "Move my 2 PM meeting to 3 PM" or "Cancel my standup tomorrow"; the agent looks the event up with get_calendar_event and then calls update_calendar_event or delete_calendar_event. |
+
 ## Skills (loaded into the system prompt)
 
 | Skill | Description | Source |
 |-------|-------------|--------|
 | `schedule-meeting` | Use this when the user asks to schedule a meeting, book a slot, or find a time that works. Resolves a conflict-free booking by finding open slots, validating no overlap, and creating the event. | bare scaffold (`skills/schedule-meeting.md`) |
+
+## Documentation
+- [Setup](docs/setup.md)
+- [Configuration](docs/configuration.md)
+- [Usage](docs/usage.md)
 
 ## Configuration
 

--- a/agent.yaml
+++ b/agent.yaml
@@ -323,3 +323,40 @@ spec:
         opencode:
           enabled: false
     deps: []
+  examples:
+    - title: List upcoming events
+      description: >-
+        Ask "What's on my calendar this week?" and the agent calls
+        list_calendar_events to return your upcoming events with their
+        times, locations, and attendees.
+    - title: Schedule a conflict-free meeting
+      description: >-
+        Ask "Schedule a 30-minute sync with alice@example.com tomorrow
+        afternoon." The schedule-meeting skill chains find_available_time,
+        check_conflicts, and create_calendar_event to book a slot that does
+        not overlap anything already on the calendar.
+    - title: Find a free time slot
+      description: >-
+        Ask "Find a free 1-hour slot on Thursday" and the agent uses
+        find_available_time to propose open windows, anchoring "Thursday" to
+        your timezone with get_current_datetime first.
+    - title: Reschedule or cancel an event
+      description: >-
+        Ask "Move my 2 PM meeting to 3 PM" or "Cancel my standup tomorrow";
+        the agent looks the event up with get_calendar_event and then calls
+        update_calendar_event or delete_calendar_event.
+  documentation:
+    pages:
+      - title: Setup
+        path: docs/setup.md
+        description: Install, build, and run the Google Calendar agent.
+      - title: Configuration
+        path: docs/configuration.md
+        description: >-
+          Environment variables for the LLM client, Google Calendar
+          credentials, mock mode, and the server.
+      - title: Usage
+        path: docs/usage.md
+        description: >-
+          Available calendar tools, the schedule-meeting skill, timezone
+          handling, and example requests.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,53 @@
+# Configuration
+
+The agent is configured through environment variables. Defaults come from
+`spec.config.*` in `agent.yaml`; the variables below override them at runtime.
+
+## Google Calendar
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `GOOGLE_SERVICE_ACCOUNT_JSON` | Service account credentials as a single-line JSON string | `` |
+| `GOOGLE_CREDENTIALS_PATH` | Path to a Google credentials JSON file | `` |
+| `GOOGLE_CALENDAR_ID` | Calendar to operate on | `primary` |
+| `GOOGLE_CALENDAR_MOCK_MODE` | Serve in-memory mock data instead of calling Google | `false` |
+| `GOOGLE_CALENDAR_TIMEZONE` | Default IANA timezone when a request does not specify one | `UTC` |
+
+Provide credentials with either `GOOGLE_SERVICE_ACCOUNT_JSON` (inline) or
+`GOOGLE_CREDENTIALS_PATH` (file). Share the target calendar with the service
+account's email address so it can read and write events.
+
+When `GOOGLE_CALENDAR_MOCK_MODE=true`, credentials are not required and the
+agent returns deterministic sample data — useful for demos and local testing.
+
+## LLM client
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `A2A_AGENT_CLIENT_PROVIDER` | LLM provider (`openai`, `anthropic`, `azure`, `ollama`, `deepseek`) | `` |
+| `A2A_AGENT_CLIENT_MODEL` | Model identifier | `` |
+| `A2A_AGENT_CLIENT_API_KEY` | Provider API key | - |
+| `A2A_AGENT_CLIENT_BASE_URL` | Custom endpoint (optional) | - |
+| `A2A_AGENT_CLIENT_MAX_TOKENS` | Maximum tokens per response | `4096` |
+| `A2A_AGENT_CLIENT_TEMPERATURE` | Sampling temperature | `0.7` |
+
+## Server
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `A2A_PORT` | Server port | `8080` |
+| `A2A_DEBUG` | Enable debug logging | `false` |
+| `A2A_SERVER_READ_TIMEOUT` | HTTP read timeout | `120s` |
+| `A2A_SERVER_WRITE_TIMEOUT` | HTTP write timeout | `120s` |
+
+## Read tool
+
+The agent loads skill playbooks from disk with a built-in `read` tool.
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `TOOLS_READ_ENABLED` | Enable the read tool | `true` |
+| `TOOLS_READ_MAX_LINES` | Maximum lines returned per read | `2000` |
+
+The [README](../README.md#environment-variables) lists the complete
+environment variable reference, including task-retention and storage settings.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,0 +1,64 @@
+# Setup
+
+This guide covers installing, building, and running the Google Calendar
+agent — an [A2A](https://github.com/inference-gateway/adk) server that exposes
+Google Calendar operations to AI assistants.
+
+## Prerequisites
+
+- Go 1.26.4+ (only needed to build or run from source)
+- An OpenAI-compatible LLM provider and API key
+- Google Calendar credentials — a service account JSON or a credentials file
+  (not required in mock mode; see [Configuration](configuration.md))
+
+## Run from source
+
+```bash
+# Start the A2A server (defaults to port 8080)
+go run . start
+```
+
+## Build the binary
+
+```bash
+task build
+./bin/google-calendar-agent --version
+./bin/google-calendar-agent start
+```
+
+`start` boots the server and blocks until it receives SIGINT/SIGTERM. The
+root command also exposes `--help` and `--version`.
+
+## Run with Docker
+
+```bash
+docker build -t google-calendar-agent .
+docker run -p 8080:8080 google-calendar-agent
+```
+
+## Minimal configuration
+
+The agent needs an LLM provider to interpret requests. Set these before
+starting:
+
+```bash
+export A2A_AGENT_CLIENT_PROVIDER=openai   # openai, anthropic, azure, ollama, deepseek
+export A2A_AGENT_CLIENT_MODEL=gpt-4o
+export A2A_AGENT_CLIENT_API_KEY=sk-...
+```
+
+To try the agent without Google credentials, enable mock mode:
+
+```bash
+export GOOGLE_CALENDAR_MOCK_MODE=true
+```
+
+See [Configuration](configuration.md) for the full list of variables and
+[Usage](usage.md) for example requests.
+
+## Verify it is running
+
+```bash
+curl http://localhost:8080/health
+curl http://localhost:8080/.well-known/agent-card.json
+```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,56 @@
+# Usage
+
+Once the agent is running (see [Setup](setup.md)), you interact with it over
+the A2A protocol. It translates natural-language calendar requests into calls
+to the tools below.
+
+## Endpoints
+
+- `POST /a2a` — A2A protocol endpoint (JSON-RPC 2.0)
+- `GET /.well-known/agent-card.json` — agent metadata and capabilities
+- `GET /health` — health check
+
+## Tools
+
+| Tool | What it does |
+|------|--------------|
+| `list_calendar_events` | List upcoming events, optionally filtered by time range or search query |
+| `get_calendar_event` | Fetch the details of a single event by ID |
+| `create_calendar_event` | Create an event with a summary, start/end time, attendees, and location |
+| `update_calendar_event` | Change the time, summary, or location of an existing event |
+| `delete_calendar_event` | Remove an event by ID |
+| `find_available_time` | Propose open slots of a given duration within a date range |
+| `check_conflicts` | Report whether a time range overlaps existing events |
+| `get_current_datetime` | Return the current time and the user's IANA timezone |
+
+## Timezone handling
+
+For any time-relative request ("today", "tomorrow", "next Friday"), the agent
+calls `get_current_datetime` first to anchor the current time and timezone,
+then emits RFC3339 timestamps with the correct offset. Set
+`GOOGLE_CALENDAR_TIMEZONE` (see [Configuration](configuration.md)) to control
+the default when a request does not name a timezone.
+
+## schedule-meeting skill
+
+When you ask to book a meeting, the agent loads the `schedule-meeting`
+playbook (`skills/schedule-meeting/SKILL.md`) and chains
+`find_available_time` → `check_conflicts` → `create_calendar_event` to produce
+a conflict-free booking.
+
+## Try it with the A2A Debugger
+
+```bash
+docker run --rm -it --network host \
+  ghcr.io/inference-gateway/a2a-debugger:latest \
+  --server-url http://localhost:8080 tasks submit "What's on my calendar today?"
+```
+
+More example requests to try:
+
+```text
+Schedule a 30 minute sync with alice@example.com tomorrow afternoon
+Find a free 1-hour slot for the team on Thursday
+Move my 2 PM meeting to 3 PM
+Cancel my standup tomorrow
+```


### PR DESCRIPTION
Adds spec.examples (4 entries) and spec.documentation.pages (Setup, Configuration, Usage) to agent.yaml, plus hand-written docs pages under docs/. These ADL schema sections (adl-cli 0.49.0+) were never authored here.

Changes:
- spec.examples: List upcoming events, Schedule a conflict-free meeting, Find a free time slot, Reschedule or cancel an event.
- spec.documentation.pages: Setup, Configuration, Usage.
- New docs/setup.md, docs/configuration.md, docs/usage.md (short and factual).
- Regenerated README.md so the Examples and Documentation sections surface.

spec.tools, spec.skills, spec.config, and spec.services are unchanged. adl validate agent.yaml passes.

Closes #90

Generated with [Claude Code](https://claude.ai/code)
